### PR TITLE
Update to latest logdna-ruby in gemspec

### DIFF
--- a/logdna-rails.gemspec
+++ b/logdna-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'logdna', '~> 1.0.7'
+  spec.add_runtime_dependency 'logdna', '~> 1.1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.5'


### PR DESCRIPTION
Bump [logdna-ruby](https://github.com/logdna/ruby) version 1.0.7 -> 1.1.1.

This fixes issues we were running into, which were patched in later versions of the dependency.